### PR TITLE
Tons of enhancements to Khador

### DIFF
--- a/Khador_Reckoning(2015).cat
+++ b/Khador_Reckoning(2015).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="22db-330b-10c0-722b" revision="7" gameSystemId="b978a3ef-974a-4354-b82d-7965f519d3df" gameSystemRevision="2" battleScribeVersion="1.15" name="Khador" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2c35-dc21-6d5a-80a2" revision="8" gameSystemId="b978a3ef-974a-4354-b82d-7965f519d3df" gameSystemRevision="2" battleScribeVersion="1.15" name="Khador" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="8058c02e-db92-21aa-3d1d-a2e86070623a" name="Alexia Ciannor, The Risen, &amp; Thrall Warrior" points="5.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="51">
       <entries>
@@ -409,16 +409,8 @@
         </link>
       </links>
     </entry>
-    <entry id="1e84-2411-b460-f7ba" name="Assault Kommandos" points="5.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="86">
+    <entry id="1e84-2411-b460-f7ba" name="Assault Kommandos" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="86">
       <entries>
-        <entry id="4051-611f-3876-fb93" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="cff4-048a-96bc-0a2a" name="Leader &amp; Grunts" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="cc92-fd9b-5699-c12a" name="Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -507,7 +499,7 @@
             </link>
           </links>
         </entry>
-        <entry id="40f8-4f4b-7cd6-4eed" name="Assault Kommando Flame Thrower" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="87">
+        <entry id="40f8-4f4b-7cd6-4eed" name="Assault Kommando Flame Thrower" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="87">
           <entries>
             <entry id="f64f-0dc5-7a9f-9e88" name="Flamethrower" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
@@ -556,7 +548,7 @@
               </profiles>
               <links/>
             </entry>
-            <entry id="c1a2-ca81-bc1b-d392" name="1 Flame Thrower" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="050c-b3ce-5a1c-0ec9" name="Assault Kommando Flame Thrower" points="1.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -608,7 +600,31 @@
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="1203-d708-bc93-2878" name="Squad Size" defaultEntryId="98b0-95e1-6d97-94b7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="98b0-95e1-6d97-94b7" name="Leader and 5 Grunts" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="90cb-524a-c4ec-5100" name="Leader and 9 Grunts" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -630,7 +646,7 @@
       <profiles/>
       <links/>
     </entry>
-    <entry id="c742-c9be-09ff-652f" name="Battle Mechaniks" points="2.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="88">
+    <entry id="c742-c9be-09ff-652f" name="Battle Mechaniks" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="88">
       <entries>
         <entry id="ed09-685e-2aed-e957" name="Monkey Wrench" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -650,14 +666,6 @@
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="f839-87ff-5952-d5ab" name="Leader &amp; 3 Grunts -&gt; Leader &amp; 5 Grunts" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
           <links/>
         </entry>
         <entry id="c9ff-6c43-32ec-14ee" name="Battle Mechanik Officer" points="2.0" categoryId="556e697423232344415441232323" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Wrath" page="73">
@@ -727,7 +735,31 @@
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="fdc7-fa24-1f53-df70" name="Squad Size" defaultEntryId="c878-3b03-4f27-79b4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="c878-3b03-4f27-79b4" name="Leader and 3 Grunts" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="c390-f506-90bb-e2e1" name="Leader and 5 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -742,11 +774,11 @@
         </modifier>
       </modifiers>
       <rules>
-        <rule id="a4b0-839d-dd4e-605b" name="Assist Repair (* Action)" hidden="false">
+        <rule id="a4b0-839d-dd4e-605b" name="Assist Repair (★ Action)" hidden="false">
           <description>This model can make this special action only when B2B with a friendly Faction warjack. When this model makes an Assist Repair special action, choose another model in this unit with the Repair ability also B2B with that warjack. The chosen model gains a cumulative +1 to its Repair skill on its next Repair skill check to repair that warjack this activation. If it passes the Repair check, remove 1 additional damage point from the warjack for each model that used Assist Repair on the chosen model.</description>
           <modifiers/>
         </rule>
-        <rule id="5020-f723-32c8-b256" name="Repair[7] (* Action)" hidden="false" book="Forces of Warmachine: Khador" page="88">
+        <rule id="5020-f723-32c8-b256" name="Repair[7] (★ Action)" hidden="false" book="Forces of Warmachine: Khador" page="88">
           <description>This model can attempt repairs on any damaged friendly Faction warjack. To attempt repairs, this model must be B2B with the damaged warjack and make a skill check. If successful, remove d6 damage points from the warjack&apos;s damage grid.</description>
           <modifiers/>
         </rule>
@@ -1780,16 +1812,8 @@
         </link>
       </links>
     </entry>
-    <entry id="f955a464-d66d-73e4-1d16-1b3a9cf9eb58" name="Croe&apos;s Cutthroats" points="7.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="58">
+    <entry id="f955a464-d66d-73e4-1d16-1b3a9cf9eb58" name="Croe&apos;s Cutthroats" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="58">
       <entries>
-        <entry id="93b057f2-a48f-e77b-fe0e-8044e1864c12" name="Croe &amp; 5 Grunts -&gt; Croe &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="77e8-d71b-0aeb-999d" name="Grunt" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="f45a-cda8-13c4-38fa" name="Crossbow" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -1950,7 +1974,31 @@
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="d742-0c68-6d44-35a3" name="Squad Size" defaultEntryId="9c4e-1f7d-3a9b-0b6c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="9c4e-1f7d-3a9b-0b6c" name="Croe and 5 Grunts" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="4e57-45c2-0ed6-b76c" name="Croe and 9 Grunts" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -2004,16 +2052,8 @@
         </link>
       </links>
     </entry>
-    <entry id="3ae7c437-1ddc-2931-6e88-c10b129c6145" name="Cylena Raefyll &amp; Nyss Hunters" points="7.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="62">
+    <entry id="3ae7c437-1ddc-2931-6e88-c10b129c6145" name="Cylena Raefyll &amp; Nyss Hunters" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="62">
       <entries>
-        <entry id="8d049073-a6f6-57d8-b012-b514a6662262" name="Cylena &amp; 5 Grunts -&gt; Cylena &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="1a65-2224-e6b5-4dfb" name="Cylena" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="6db3-0382-b15c-32d4" name="Nyss  Bow" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -2171,7 +2211,31 @@
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="1956-c090-a435-3483" name="Squad Size" defaultEntryId="9c6d-2ff2-3ccc-600a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="9c6d-2ff2-3ccc-600a" name="Cylena and 5 Grunts" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="2129-b4ea-6fb8-346b" name="Cylena and 9 Grunts" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -4865,16 +4929,8 @@
       <profiles/>
       <links/>
     </entry>
-    <entry id="ed0c13f6-8561-0351-9f2a-ca9070bc91e0" name="Greygore Boomhowler &amp; Co." points="6.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="56">
+    <entry id="ed0c13f6-8561-0351-9f2a-ca9070bc91e0" name="Greygore Boomhowler &amp; Co." points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="56">
       <entries>
-        <entry id="04b24049-b3ff-5e09-c05b-d2f38280c771" name="Boomhowler &amp; 5 Grunts -&gt; Boomhowler &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="5fb7-515a-72a9-34ed" name="Grunt" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="e1ea-1812-8256-9b0d" name="Blunderbuss" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -5030,7 +5086,31 @@
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="8415-afb8-00ce-0c3f" name="Squad Size" defaultEntryId="1f6d-fd4d-62f5-9ef7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="1f6d-fd4d-62f5-9ef7" name="Boomhowler and 5 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="c3b1-a170-1d75-5b7a" name="Boomhowler and 9 Grunts" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -5061,7 +5141,7 @@
         </link>
       </links>
     </entry>
-    <entry id="e846-93d4-977b-a52c" name="Greylord Outriders" points="6.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Vengeance" page="62">
+    <entry id="e846-93d4-977b-a52c" name="Greylord Outriders" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Vengeance" page="62">
       <entries>
         <entry id="886a-034f-a752-c2cb" name="Rune Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -5107,21 +5187,38 @@
           </profiles>
           <links/>
         </entry>
-        <entry id="b897-ae49-1a64-b2cc" name="Leader &amp; 2 Grunts -&gt; Leader &amp; 4 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
+      </entries>
+      <entryGroups>
+        <entryGroup id="5b21-0df7-5ca0-8fc8" name="Squad Size" defaultEntryId="799d-43ad-cfaf-1923" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="799d-43ad-cfaf-1923" name="Leader and 2 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="a3c4-81b6-023f-1d3b" name="Leader and 4 Grunts" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
           <entryGroups/>
           <modifiers/>
-          <rules/>
-          <profiles/>
           <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules>
         <rule id="66c2-a40d-b185-9c5f" name="Magic Ability [6]" hidden="false">
-          <description>- Frostbite (* Attack) - Frostbite is a RNG SP 8 magic attack. Models hit suffer a POW 12 cold damage roll.
-- Winter&apos;s Wind (* Action) - RNG 5. Target friendly Faction model with Immunity: Cold. When an enemy model without Immunity: Cold ends its activation within 2&quot; of the target model, the enemy model becomes stationary for one round. Winter&apos;s Wind lasts for one round.</description>
+          <description>
+◦ Frostbite (★ Attack) — Frostbite is a RNG SP 8 magic attack. Models hit suffer a POW 12 cold damage roll.
+◦ Winter&apos;s Wind (★ Action) — RNG 5. Target friendly Faction model with Immunity: Cold. When an enemy model without Immunity: Cold ends its activation within 2&quot; of the target model, the enemy model becomes stationary for one round. Winter&apos;s Wind lasts for one round.</description>
           <modifiers/>
         </rule>
         <rule id="93fb-1e96-b12e-d972" name="Snow-Wreathed" hidden="false">
@@ -5190,9 +5287,10 @@
       <modifiers/>
       <rules>
         <rule id="e575-59bf-d5c8-f6cc" name="Magical Ability [7]" hidden="false">
-          <description>- Blizzard (* Action) - RNG 5. Target friendly Faction model. If the model is in range, center a 3&quot; AOE cloud effect on it. The AOE remains centered on the model for one round. If the target model is destroyed or removed from play, remove the AOE from play.
-- Frostbite (* Attack) - Frostbite is a RNG SP 8 magic attack. Models hit suffer a POW 12 cold damage roll.
-- Ice Cage (* Attack) - Ice Cage is a RNG 10 magic attack. A model hit suffers a cumulative -2 DEF for one turn unless it has mmunity: Cold. When a model without Immunity: Cold is hit with three or more Ice Cage attacks the same turn, it becomes stationary for one round.</description>
+          <description>
+◦ Blizzard (★ Action) - RNG 5. Target friendly Faction model. If the model is in range, center a 3&quot; AOE cloud effect on it. The AOE remains centered on the model for one round. If the target model is destroyed or removed from play, remove the AOE from play.
+◦ Frostbite (★ Attack) - Frostbite is a RNG SP 8 magic attack. Models hit suffer a POW 12 cold damage roll.
+◦ Ice Cage (★ Attack) - Ice Cage is a RNG 10 magic attack. A model hit suffers a cumulative -2 DEF for one turn unless it has mmunity: Cold. When a model without Immunity: Cold is hit with three or more Ice Cage attacks the same turn, it becomes stationary for one round.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -5483,16 +5581,8 @@
         </link>
       </links>
     </entry>
-    <entry id="cd64395a-e9f8-aa0f-06eb-d9147e501161" name="Hammerfall High Shield Gun Corps" points="5.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="146">
+    <entry id="cd64395a-e9f8-aa0f-06eb-d9147e501161" name="Hammerfall High Shield Gun Corps" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="146">
       <entries>
-        <entry id="9bbe6013-70c7-90f0-7d19-e408f0612166" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="ff3a1f03-abc0-cbc6-73e5-e6cb6451807e" name="Hammerfall High Shield Officer &amp; Standard" points="3.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="147">
           <entries/>
           <entryGroups/>
@@ -5623,7 +5713,31 @@
           <links/>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="fd1d-bdd0-7b0e-fdc7" name="Squad Size" defaultEntryId="1505-606b-6c65-3c2a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="1505-606b-6c65-3c2a" name="Leader amd 5 Grunts" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="f367-986f-c0d2-8381" name="Leader and 9 Grunts" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -6068,7 +6182,7 @@
           <description>This model and firendly Iron Fang models in its command range cannot be knocked down.</description>
           <modifiers/>
         </rule>
-        <rule id="b0c1-2c5a-04e8-5b57" name="Shield March (* Action)" hidden="false">
+        <rule id="b0c1-2c5a-04e8-5b57" name="Shield March (★ Action)" hidden="false">
           <description>TNG 5. Target friendly Faction unit. If the unit is in range, when it receives the Shield Wall order, the models in the unit gain +2&quot; movement that activation. Shield March lasts for one turn.</description>
           <modifiers/>
         </rule>
@@ -6103,16 +6217,8 @@
         </link>
       </links>
     </entry>
-    <entry id="6c03-7219-7b0e-8abd" name="Iron Fang Pikemen" points="5.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="92">
+    <entry id="6c03-7219-7b0e-8abd" name="Iron Fang Pikemen" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="92">
       <entries>
-        <entry id="a47e-2772-d7d1-8bda" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="ced6-ed1c-78c6-a195" name="Blasting Pike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -6140,33 +6246,123 @@
             </link>
           </links>
         </entry>
-        <entry id="b1e3-c107-52b6-f77a" name="Iron Fang Officer &amp; Standard" points="2.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="93">
+      </entries>
+      <entryGroups>
+        <entryGroup id="8864-28ec-490f-d1db" name="Squad Size" defaultEntryId="7079-5c79-d8da-d11f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="ecee-1426-3050-8971" name="Officer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="7079-5c79-d8da-d11f" name="Leader and 5 Grunts" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="51e7-a619-fe4f-309d" name="Leader and 9 Grunts" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="8a34-d763-92e7-51b8" name="Officer and Standard" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="72f9-a160-58f7-ed99" name="Iron Fang Officer &amp; Standard" points="2.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="93">
               <entries>
-                <entry id="f344-6cac-6051-8df5" name="Blasting Pike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
+                <entry id="a41f-7028-0a9c-50b1" name="Officer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="e2bd-7d07-83dc-0c3c" name="Blasting Pike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles>
+                        <profile id="f3ab-a8cb-1c66-8e2f" profileTypeId="576561706f6e23232344415441232323" name="Blasting Pike" hidden="false">
+                          <characteristics>
+                            <characteristic characteristicId="524e4723232344415441232323" name="RNG"/>
+                            <characteristic characteristicId="524f4623232344415441232323" name="ROF"/>
+                            <characteristic characteristicId="414f4523232344415441232323" name="AOE"/>
+                            <characteristic characteristicId="504f5723232344415441232323" name="POW" value="7"/>
+                            <characteristic characteristicId="502b5323232344415441232323" name="P+S" value="13"/>
+                            <characteristic characteristicId="4c2f522f4823232344415441232323" name="L/R/H"/>
+                          </characteristics>
+                          <modifiers/>
+                        </profile>
+                      </profiles>
+                      <links>
+                        <link id="d9c4-0089-aa88-18fb" targetId="c950cf4c-33a0-1369-1946-ff2bb9ca7528" linkType="rule">
+                          <modifiers/>
+                        </link>
+                        <link id="fcde-8cd3-7bd7-a478" targetId="107dd7f7-39ae-6416-0421-1406d4ea886b" linkType="rule">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
                   <entryGroups/>
                   <modifiers/>
-                  <rules/>
+                  <rules>
+                    <rule id="0be5-de9b-86db-610e" name="Defensive Formation" hidden="false">
+                      <description>Once per game during its unit&apos;s activation, this model can use Defensive Formation. Immediately after models in this unit complete their activations this turn, models in this unit other than this one can make a full advance, any previous orders this unit was issued expire, and this unit is affected by the Shield Wall order.</description>
+                      <modifiers/>
+                    </rule>
+                    <rule id="622b-8feb-0dde-53a1" name="Tactics: Relentless Charge" hidden="false">
+                      <description>Models in this unit gain Relentless Charge. (Models with Relentless Charge gain Pathfinder during activations they charge.)</description>
+                      <modifiers/>
+                    </rule>
+                  </rules>
                   <profiles>
-                    <profile id="27e5-1016-a61e-beca" profileTypeId="576561706f6e23232344415441232323" name="Blasting Pike" hidden="false">
+                    <profile id="52bb-f16a-1c61-cc5e" profileTypeId="54726f6f70657223232344415441232323" name="Officer" hidden="false">
                       <characteristics>
-                        <characteristic characteristicId="524e4723232344415441232323" name="RNG"/>
-                        <characteristic characteristicId="524f4623232344415441232323" name="ROF"/>
-                        <characteristic characteristicId="414f4523232344415441232323" name="AOE"/>
-                        <characteristic characteristicId="504f5723232344415441232323" name="POW" value="7"/>
-                        <characteristic characteristicId="502b5323232344415441232323" name="P+S" value="13"/>
-                        <characteristic characteristicId="4c2f522f4823232344415441232323" name="L/R/H"/>
+                        <characteristic characteristicId="53504423232344415441232323" name="SPD" value="6"/>
+                        <characteristic characteristicId="53545223232344415441232323" name="STR" value="6"/>
+                        <characteristic characteristicId="4d415423232344415441232323" name="MAT" value="7"/>
+                        <characteristic characteristicId="52415423232344415441232323" name="RAT" value="4"/>
+                        <characteristic characteristicId="44454623232344415441232323" name="DEF" value="13"/>
+                        <characteristic characteristicId="41524d23232344415441232323" name="ARM" value="14"/>
+                        <characteristic characteristicId="434d4423232344415441232323" name="CMD" value="10"/>
+                        <characteristic characteristicId="44616d61676523232344415441232323" name="Damage" value="5"/>
                       </characteristics>
                       <modifiers/>
                     </profile>
                   </profiles>
                   <links>
-                    <link id="e07a-c3cf-9cea-92fe" targetId="c950cf4c-33a0-1369-1946-ff2bb9ca7528" linkType="rule">
+                    <link id="0407-62e5-98ae-2a67" targetId="a25ad4f2-ec5d-7dbd-c929-cd95c4fda530" linkType="rule">
                       <modifiers/>
                     </link>
-                    <link id="8157-1c31-f05f-108f" targetId="107dd7f7-39ae-6416-0421-1406d4ea886b" linkType="rule">
+                    <link id="78c3-25b0-8366-49ac" targetId="43190c68-0893-f7d9-ad1f-cec11538fc72" linkType="rule">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="c70d-5449-d7c3-5ae4" name="Standard Bearer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles>
+                    <profile id="dfa2-d120-a5dd-0928" profileTypeId="4d79726d69646f6e23232344415441232323" name="Standard Bearer" hidden="false">
+                      <characteristics>
+                        <characteristic characteristicId="53504423232344415441232323" name="SPD"/>
+                        <characteristic characteristicId="53545223232344415441232323" name="STR"/>
+                        <characteristic characteristicId="4d415423232344415441232323" name="MAT"/>
+                        <characteristic characteristicId="52415423232344415441232323" name="RAT"/>
+                        <characteristic characteristicId="44454623232344415441232323" name="DEF"/>
+                        <characteristic characteristicId="41524d23232344415441232323" name="ARM"/>
+                        <characteristic characteristicId="434d4423232344415441232323" name="CMD"/>
+                        <characteristic characteristicId="4669656c642044616d61676523232344415441232323" name="Field Damage"/>
+                      </characteristics>
+                      <modifiers/>
+                    </profile>
+                  </profiles>
+                  <links>
+                    <link id="1b89-616b-d739-582f" targetId="ea4b6c9d-9e17-58f3-8163-8ea99d5db0fe" linkType="rule">
                       <modifiers/>
                     </link>
                   </links>
@@ -6175,76 +6371,131 @@
               <entryGroups/>
               <modifiers/>
               <rules>
-                <rule id="abe7-a28d-1a5b-0819" name="Defensive Formation" hidden="false">
-                  <description>Once per game during its unit&apos;s activation, this model can use Defensive Formation. Immediately after models in this unit complete their activations this turn, models in this unit other than this one can make a full advance, any previous orders this unit was issued expire, and this unit is affected by the Shield Wall order.</description>
-                  <modifiers/>
-                </rule>
-                <rule id="7b26-0c46-e6ee-08a6" name="Tactics: Relentless Charge" hidden="false">
-                  <description>Models in this unit gain Relentless Charge. (Models with Relentless Charge gain Pathfinder during activations they charge.)</description>
+                <rule id="f436-4b68-a5b4-e13c" name="Attachment [Iron Fang Pikemen]" hidden="false">
+                  <description>This attachment can be added to an Iron Fang Pikemen unit.</description>
                   <modifiers/>
                 </rule>
               </rules>
-              <profiles>
-                <profile id="c0b9-45b1-59f2-dd0a" profileTypeId="54726f6f70657223232344415441232323" name="Officer" hidden="false">
-                  <characteristics>
-                    <characteristic characteristicId="53504423232344415441232323" name="SPD" value="6"/>
-                    <characteristic characteristicId="53545223232344415441232323" name="STR" value="6"/>
-                    <characteristic characteristicId="4d415423232344415441232323" name="MAT" value="7"/>
-                    <characteristic characteristicId="52415423232344415441232323" name="RAT" value="4"/>
-                    <characteristic characteristicId="44454623232344415441232323" name="DEF" value="13"/>
-                    <characteristic characteristicId="41524d23232344415441232323" name="ARM" value="14"/>
-                    <characteristic characteristicId="434d4423232344415441232323" name="CMD" value="10"/>
-                    <characteristic characteristicId="44616d61676523232344415441232323" name="Damage" value="5"/>
-                  </characteristics>
-                  <modifiers/>
-                </profile>
-              </profiles>
-              <links>
-                <link id="3f0f-07c7-0d5d-9e0d" targetId="a25ad4f2-ec5d-7dbd-c929-cd95c4fda530" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
+              <profiles/>
+              <links/>
             </entry>
-            <entry id="99a0-a2a7-6e5e-5772" name="Standard Bearer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
+            <entry id="278d-216c-36d4-50d1" name="Black Dragon" points="2.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="No Quarter Magazine Issue 40" page="30">
+              <entries>
+                <entry id="16d9-80c3-9cb9-602d" name="Officer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries>
+                    <entry id="f4e3-e9b1-da0d-b6e5" name="Blasting Pike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                      <entries/>
+                      <entryGroups/>
+                      <modifiers/>
+                      <rules/>
+                      <profiles>
+                        <profile id="04da-48d8-e6f0-eb74" profileTypeId="576561706f6e23232344415441232323" name="Blasting Pike" hidden="false">
+                          <characteristics>
+                            <characteristic characteristicId="524e4723232344415441232323" name="RNG"/>
+                            <characteristic characteristicId="524f4623232344415441232323" name="ROF"/>
+                            <characteristic characteristicId="414f4523232344415441232323" name="AOE"/>
+                            <characteristic characteristicId="504f5723232344415441232323" name="POW" value="7"/>
+                            <characteristic characteristicId="502b5323232344415441232323" name="P+S" value="13"/>
+                            <characteristic characteristicId="4c2f522f4823232344415441232323" name="L/R/H"/>
+                          </characteristics>
+                          <modifiers/>
+                        </profile>
+                      </profiles>
+                      <links>
+                        <link id="4fac-bde6-51f8-ebf1" targetId="c950cf4c-33a0-1369-1946-ff2bb9ca7528" linkType="rule">
+                          <modifiers/>
+                        </link>
+                        <link id="34f4-2ed0-e65d-6ed1" targetId="107dd7f7-39ae-6416-0421-1406d4ea886b" linkType="rule">
+                          <modifiers/>
+                        </link>
+                      </links>
+                    </entry>
+                  </entries>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules>
+                    <rule id="cbea-8834-2df4-17d4" name="Iron Zeal" hidden="false">
+                      <description>Once per game during its unit’s activation, this model can use Iron Zeal. For one round, while in formation models in this unit gain +4 ARM and cannot become stationary or be knocked down.</description>
+                      <modifiers/>
+                    </rule>
+                    <rule id="dffc-1ee8-c4bc-045c" name="Tactics: Precision Strike" hidden="false">
+                      <description>Models in this unit gain Precision Strike. (When a model with Precision Strike damages a warjack or warbeast with a melee attack, choose which column or branch suffers the damage.)</description>
+                      <modifiers/>
+                    </rule>
+                  </rules>
+                  <profiles>
+                    <profile id="705b-62e1-3acb-cd85" profileTypeId="54726f6f70657223232344415441232323" name="Officer" hidden="false">
+                      <characteristics>
+                        <characteristic characteristicId="53504423232344415441232323" name="SPD" value="6"/>
+                        <characteristic characteristicId="53545223232344415441232323" name="STR" value="6"/>
+                        <characteristic characteristicId="4d415423232344415441232323" name="MAT" value="7"/>
+                        <characteristic characteristicId="52415423232344415441232323" name="RAT" value="4"/>
+                        <characteristic characteristicId="44454623232344415441232323" name="DEF" value="13"/>
+                        <characteristic characteristicId="41524d23232344415441232323" name="ARM" value="14"/>
+                        <characteristic characteristicId="434d4423232344415441232323" name="CMD" value="10"/>
+                        <characteristic characteristicId="44616d61676523232344415441232323" name="Damage" value="5"/>
+                      </characteristics>
+                      <modifiers/>
+                    </profile>
+                  </profiles>
+                  <links>
+                    <link id="79c1-140b-ca81-6ae2" targetId="a25ad4f2-ec5d-7dbd-c929-cd95c4fda530" linkType="rule">
+                      <modifiers/>
+                    </link>
+                    <link id="ba91-fd7f-f292-ffd1" targetId="43190c68-0893-f7d9-ad1f-cec11538fc72" linkType="rule">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="7c82-9ed4-a5be-3160" name="Standard Bearer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules>
+                    <rule id="cd78-c10d-c3a7-505f" name="Granted: Fearless" hidden="false">
+                      <description>While this model is in play, models in its unit gain Fearless.</description>
+                      <modifiers/>
+                    </rule>
+                  </rules>
+                  <profiles>
+                    <profile id="afc5-058c-b441-5269" profileTypeId="4d79726d69646f6e23232344415441232323" name="Standard Bearer" hidden="false">
+                      <characteristics>
+                        <characteristic characteristicId="53504423232344415441232323" name="SPD"/>
+                        <characteristic characteristicId="53545223232344415441232323" name="STR"/>
+                        <characteristic characteristicId="4d415423232344415441232323" name="MAT"/>
+                        <characteristic characteristicId="52415423232344415441232323" name="RAT"/>
+                        <characteristic characteristicId="44454623232344415441232323" name="DEF"/>
+                        <characteristic characteristicId="41524d23232344415441232323" name="ARM"/>
+                        <characteristic characteristicId="434d4423232344415441232323" name="CMD"/>
+                        <characteristic characteristicId="4669656c642044616d61676523232344415441232323" name="Field Damage"/>
+                      </characteristics>
+                      <modifiers/>
+                    </profile>
+                  </profiles>
+                  <links>
+                    <link id="2800-642a-b436-1cab" targetId="ea4b6c9d-9e17-58f3-8163-8ea99d5db0fe" linkType="rule">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+              </entries>
               <entryGroups/>
               <modifiers/>
-              <rules/>
-              <profiles>
-                <profile id="0afc-a0c6-6f54-cbe3" profileTypeId="4d79726d69646f6e23232344415441232323" name="Standard Bearer" hidden="false">
-                  <characteristics>
-                    <characteristic characteristicId="53504423232344415441232323" name="SPD"/>
-                    <characteristic characteristicId="53545223232344415441232323" name="STR"/>
-                    <characteristic characteristicId="4d415423232344415441232323" name="MAT"/>
-                    <characteristic characteristicId="52415423232344415441232323" name="RAT"/>
-                    <characteristic characteristicId="44454623232344415441232323" name="DEF"/>
-                    <characteristic characteristicId="41524d23232344415441232323" name="ARM"/>
-                    <characteristic characteristicId="434d4423232344415441232323" name="CMD"/>
-                    <characteristic characteristicId="4669656c642044616d61676523232344415441232323" name="Field Damage"/>
-                  </characteristics>
+              <rules>
+                <rule id="5b4e-263a-2f90-9433" name="Attachment [Iron Fang Pikemen]" hidden="false">
+                  <description>This attachment can be added to an Iron Fang Pikemen unit.</description>
                   <modifiers/>
-                </profile>
-              </profiles>
-              <links>
-                <link id="d46b-dc2b-5ba3-d102" targetId="ea4b6c9d-9e17-58f3-8163-8ea99d5db0fe" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
             </entry>
           </entries>
           <entryGroups/>
           <modifiers/>
-          <rules>
-            <rule id="d2f7-68cb-1f1a-50fe" name="Attachment [Iron Fang Pikemen]" hidden="false">
-              <description>This attachment can be added to an Iron Fang Pikemen unit.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles/>
           <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -6286,7 +6537,7 @@
         </link>
       </links>
     </entry>
-    <entry id="060b-c04e-7713-2885" name="Iron Fang Uhlans" points="7.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="94">
+    <entry id="060b-c04e-7713-2885" name="Iron Fang Uhlans" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="94">
       <entries>
         <entry id="b9d7-786b-d5ba-3acb" name="Blasting Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -6363,16 +6614,32 @@
             </link>
           </links>
         </entry>
-        <entry id="78ac-f038-bbfb-6ee9" name="Leader &amp; 2 Grunts -&gt; Leader &amp; 4 Grunts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
+      </entries>
+      <entryGroups>
+        <entryGroup id="f481-1353-cbb0-d208" name="Squad Size" defaultEntryId="04d2-4ab3-16ab-86d9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="04d2-4ab3-16ab-86d9" name="Leader and 2 Grunts" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="7f48-f9b0-a59f-9709" name="Leader and 4 Grunts" points="11.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
           <entryGroups/>
           <modifiers/>
-          <rules/>
-          <profiles/>
           <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -6627,6 +6894,161 @@
           <modifiers/>
         </link>
         <link id="b2b6-4d9b-ce56-4a36" targetId="6883-f630-44c0-4e81" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="8996-dadb-ddee-0f0c" name="Kayazy Assassins" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="ee23-b786-5300-f927" name="Assassin Blade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="00df-8172-67d5-a6e0" profileTypeId="576561706f6e23232344415441232323" name="Assassin Blade" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="524e4723232344415441232323" name="RNG" value=""/>
+                <characteristic characteristicId="524f4623232344415441232323" name="ROF" value=""/>
+                <characteristic characteristicId="414f4523232344415441232323" name="AOE" value=""/>
+                <characteristic characteristicId="504f5723232344415441232323" name="POW" value="4"/>
+                <characteristic characteristicId="502b5323232344415441232323" name="P+S" value="10"/>
+                <characteristic characteristicId="4c2f522f4823232344415441232323" name="L/R/H"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="31a2-dd7f-19e6-60e1" name="Kayazy Assassin Underboss" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="21c6-9fd0-7194-6b76" name="Assassin Blade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="e8df-2f40-764d-63d1" profileTypeId="576561706f6e23232344415441232323" name="Assassin Blade" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="524e4723232344415441232323" name="RNG" value=""/>
+                    <characteristic characteristicId="524f4623232344415441232323" name="ROF" value=""/>
+                    <characteristic characteristicId="414f4523232344415441232323" name="AOE" value=""/>
+                    <characteristic characteristicId="504f5723232344415441232323" name="POW" value="4"/>
+                    <characteristic characteristicId="502b5323232344415441232323" name="P+S" value="10"/>
+                    <characteristic characteristicId="4c2f522f4823232344415441232323" name="L/R/H"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="ec73-528c-5571-d656" name="Attachment [Kayazy Assassins]" hidden="false">
+              <description>This unit can be added to a Kayazy Assassins unit.</description>
+              <modifiers/>
+            </rule>
+            <rule id="da84-93f9-0a94-d8b4" name="Tactics: Duelist" hidden="false">
+              <description>Models in this unit gain +2 DEF against melee attack rolls.</description>
+              <modifiers/>
+            </rule>
+            <rule id="0412-3ef1-f1f5-da13" name="Kill Stroke" hidden="false">
+              <description>Once per game during its unit&apos;s activation, this model can use Kill Stroke. This activation, models in this unit currently in formation can advance through other models if they have enough movement to move completely past them, ignore intevening models when declaring a charge, and cannot be targeted by free strikes</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="1554-f7ed-de45-76ff" profileTypeId="54726f6f70657223232344415441232323" name="Underboss" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="53504423232344415441232323" name="SPD" value="6"/>
+                <characteristic characteristicId="53545223232344415441232323" name="STR" value="6"/>
+                <characteristic characteristicId="4d415423232344415441232323" name="MAT" value="8"/>
+                <characteristic characteristicId="52415423232344415441232323" name="RAT" value="4"/>
+                <characteristic characteristicId="44454623232344415441232323" name="DEF" value="14"/>
+                <characteristic characteristicId="41524d23232344415441232323" name="ARM" value="11"/>
+                <characteristic characteristicId="434d4423232344415441232323" name="CMD" value="9"/>
+                <characteristic characteristicId="44616d61676523232344415441232323" name="Damage" value="5"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="8f4f-c61a-d3f2-388d" targetId="43190c68-0893-f7d9-ad1f-cec11538fc72" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="44d6-6c0d-a2cb-8ea6" targetId="e99c4320-7ab1-4678-8245-f6bb01e712e0" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="8c2b-81e3-0228-2bc3" targetId="2bcee8cd-2274-bda3-b76b-aae0edfa68ca" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="87f9-f0e6-2c12-0507" targetId="b23dca36-046b-cd8f-f956-11921b17faeb" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="13a2-7ab3-7e4f-56a2" targetId="d9bde7b1-fc2e-d6b9-eef3-1a07c166363f" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="4dd1-2798-3533-249e" targetId="ad6ef5a7-c76a-7a24-e837-f77a76cc406c" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="6b70-93bb-4409-2166" name="Squad Size" defaultEntryId="cf28-4722-6ad8-94ba" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="cf28-4722-6ad8-94ba" name="Leader and 5 Grunts" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="5211-56ec-3b24-90ef" name="Leader and 9 Grunts" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="77c9-8446-eeca-3bd7" profileTypeId="54726f6f70657223232344415441232323" name="Leader and Grunts" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="53504423232344415441232323" name="SPD" value="6"/>
+            <characteristic characteristicId="53545223232344415441232323" name="STR" value="6"/>
+            <characteristic characteristicId="4d415423232344415441232323" name="MAT" value="7"/>
+            <characteristic characteristicId="52415423232344415441232323" name="RAT" value="4"/>
+            <characteristic characteristicId="44454623232344415441232323" name="DEF" value="14"/>
+            <characteristic characteristicId="41524d23232344415441232323" name="ARM" value="11"/>
+            <characteristic characteristicId="434d4423232344415441232323" name="CMD" value="8"/>
+            <characteristic characteristicId="44616d61676523232344415441232323" name="Damage" value="1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="b6d7-f34d-f54e-1fb5" targetId="d9bde7b1-fc2e-d6b9-eef3-1a07c166363f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="da70-63c6-a795-d14a" targetId="e99c4320-7ab1-4678-8245-f6bb01e712e0" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f65d-b222-2b25-adb4" targetId="b23dca36-046b-cd8f-f956-11921b17faeb" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3f20-3fdd-9a09-7d12" targetId="ad6ef5a7-c76a-7a24-e837-f77a76cc406c" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -7942,16 +8364,8 @@
         </link>
       </links>
     </entry>
-    <entry id="e00f-4f55-9c8d-1cfd" name="Kossite Woodsmen" points="4.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="95">
+    <entry id="e00f-4f55-9c8d-1cfd" name="Kossite Woodsmen" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="95">
       <entries>
-        <entry id="a80b-43fe-20ef-c112" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="8dec-f75f-2b89-5ee3" name="Ranged Attack" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -7993,7 +8407,31 @@
           <links/>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="80b8-c0f4-222d-8779" name="Squad Size" defaultEntryId="48ab-d25e-bad2-3744" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="48ab-d25e-bad2-3744" name="Leader and 5 Gruts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="b4ad-daea-77cf-00ad" name="Leader and 9 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -8949,7 +9387,7 @@ Rigged. This model gains +2 SPD this activation. At the end of this activation, 
         </link>
       </links>
     </entry>
-    <entry id="240a-5bea-33ce-6c23" name="Man-O-War Bombardiers" points="7.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="98">
+    <entry id="240a-5bea-33ce-6c23" name="Man-O-War Bombardiers" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="98">
       <entries>
         <entry id="b3ed-d09a-5219-e66a" name="Grenade Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -8999,16 +9437,32 @@ Rigged. This model gains +2 SPD this activation. At the end of this activation, 
             </link>
           </links>
         </entry>
-        <entry id="e40c-796c-c9c0-2e45" name="Leader &amp; 2 Grunts -&gt; Leader &amp; 4 Grunts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
+      </entries>
+      <entryGroups>
+        <entryGroup id="da05-e5a0-c4e2-e30f" name="Squad Size" defaultEntryId="a022-2dfd-1da2-3b31" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="a022-2dfd-1da2-3b31" name="Leader and 2 Grunts" points="7.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="f40e-767f-c2c4-9f6c" name="Leader and 4 Grunts" points="11.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
           <entryGroups/>
           <modifiers/>
-          <rules/>
-          <profiles/>
           <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -9047,7 +9501,7 @@ Rigged. This model gains +2 SPD this activation. At the end of this activation, 
         </link>
       </links>
     </entry>
-    <entry id="7a7b-17e1-8703-9b49" name="Man-O-War Demolition Corps" points="6.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="99">
+    <entry id="7a7b-17e1-8703-9b49" name="Man-O-War Demolition Corps" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="99">
       <entries>
         <entry id="e78e-06a9-25cd-bc33" name="Ice Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -9081,16 +9535,32 @@ Rigged. This model gains +2 SPD this activation. At the end of this activation, 
             </link>
           </links>
         </entry>
-        <entry id="4b02-ca7e-6bb3-e873" name="Leader &amp; 2 Grunts -&gt; Leader &amp; 4 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
+      </entries>
+      <entryGroups>
+        <entryGroup id="5eb5-1458-701d-bf2e" name="Squad Size" defaultEntryId="db40-84a1-586c-57ca" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="db40-84a1-586c-57ca" name="Leader and 2 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="b320-9782-0b24-6455" name="Leader and 4 Grunts" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
           <entryGroups/>
           <modifiers/>
-          <rules/>
-          <profiles/>
           <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -9371,7 +9841,7 @@ Rigged. This model gains +2 SPD this activation. At the end of this activation, 
         </link>
       </links>
     </entry>
-    <entry id="b446-486d-4526-f905" name="Man-O-War Shocktroopers" points="6.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="100">
+    <entry id="b446-486d-4526-f905" name="Man-O-War Shocktroopers" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="100">
       <entries>
         <entry id="096b-fabd-f4ac-109b" name="Shield Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -9417,16 +9887,32 @@ Rigged. This model gains +2 SPD this activation. At the end of this activation, 
             </link>
           </links>
         </entry>
-        <entry id="1c3b-bfac-405c-ca30" name="Leader &amp; 2 Grunts -&gt; Leader &amp; 4 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
+      </entries>
+      <entryGroups>
+        <entryGroup id="2dde-1448-f6e6-477b" name="Squad Size" defaultEntryId="c2e0-21c7-0b86-1259" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="c2e0-21c7-0b86-1259" name="Leader and 2 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="2fed-9f6a-8660-9384" name="Leader and 4 Grunts" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
           <entryGroups/>
           <modifiers/>
-          <rules/>
-          <profiles/>
           <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -10575,16 +11061,8 @@ Solos: Doom Reaver solos, Greylord solos</description>
         </link>
       </links>
     </entry>
-    <entry id="a7c18b37-200e-53a1-ec93-8058f816e0be" name="Press Gangers" points="4.0" categoryId="556e697423232344415441232323" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="2" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="105">
+    <entry id="a7c18b37-200e-53a1-ec93-8058f816e0be" name="Press Gangers" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="2" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="105">
       <entries>
-        <entry id="2272ba52-c043-d5d6-abb0-0699201b58b3" name="Lass &amp; 5 Grunts -&gt; Lass &amp; 9 Grunts" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="b0dc-0dbd-c873-3c99" name="Grunts" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="8202-0833-15e0-f8c9" name="Hand Weapons" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -10708,7 +11186,31 @@ Solos: Doom Reaver solos, Greylord solos</description>
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="0b13-d793-0eef-5a78" name="Squad Size" defaultEntryId="22fd-99d3-43bb-e60e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="22fd-99d3-43bb-e60e" name="Lass and 5 Grunts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="2ca7-bdfb-a208-7fee" name="Lass and 9 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -11233,7 +11735,7 @@ damage rolls at one token per attack or boost.</description>
         </link>
       </links>
     </entry>
-    <entry id="52ff8af6-e8ba-9dc2-2025-b1a991e509ef" name="Sea Dog Crew" points="5.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="106">
+    <entry id="52ff8af6-e8ba-9dc2-2025-b1a991e509ef" name="Sea Dog Crew" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="106">
       <entries>
         <entry id="882f8b3a-36bb-8568-fd04-a952901e1a21" name="Sea Dog Rifleman" points="1.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="108">
           <entries>
@@ -11320,14 +11822,6 @@ damage rolls at one token per attack or boost.</description>
               <modifiers/>
             </link>
           </links>
-        </entry>
-        <entry id="550ff862-7d21-177c-7c32-1a2e9979ae74" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
         </entry>
         <entry id="11f54c4b-323b-4f6a-bf43-9edc3476c4ba" name="Mr. Walls, The Quartermaster" points="2.0" categoryId="536f6c6f23232344415441232323" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="110">
           <entries>
@@ -11439,7 +11933,31 @@ damage rolls at one token per attack or boost.</description>
           <links/>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="836f-b979-7675-7e0d" name="Squad Size" defaultEntryId="4657-a91f-3c85-6c01" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="4657-a91f-3c85-6c01" name="Leader and 5 Grunts" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="de61-29ac-e20a-970a" name="Leader and 9 Grunts" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -11882,16 +12400,8 @@ damage rolls at one token per attack or boost.</description>
         </link>
       </links>
     </entry>
-    <entry id="5b905f98-c49d-2bc2-69e8-4b56a01a13a2" name="Steelhead Halberdiers" points="4.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="3" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="48">
+    <entry id="5b905f98-c49d-2bc2-69e8-4b56a01a13a2" name="Steelhead Halberdiers" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="3" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="48">
       <entries>
-        <entry id="e2a0c181-cd72-f55e-45a1-185f3309d225" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="48">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="e751-0fec-47d7-77b8" name="Halberd" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -11923,7 +12433,31 @@ damage rolls at one token per attack or boost.</description>
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="72a2-16ed-e715-1121" name="Squad Size" defaultEntryId="84a5-a061-9261-562f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="84a5-a061-9261-562f" name="Leader and 5 Grunts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="8b8d-01be-0ea9-120b" name="Leader and 9 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -11997,16 +12531,8 @@ damage rolls at one token per attack or boost.</description>
         </link>
       </links>
     </entry>
-    <entry id="e8e9ab23-1ea3-dc6a-4479-3746d0cf7016" name="Steelhead Heavy Cavalry" points="6.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="49">
+    <entry id="e8e9ab23-1ea3-dc6a-4479-3746d0cf7016" name="Steelhead Heavy Cavalry" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="49">
       <entries>
-        <entry id="87a436bf-6aee-1e9f-d703-2db311dd9e4f" name="Leader &amp; 2 Grunts -&gt; Leader &amp; 4 Grunts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="49">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="fcb9-1e87-7983-9199" name="Cavalry Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -12058,7 +12584,31 @@ damage rolls at one token per attack or boost.</description>
           <links/>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="7155-82c7-da49-f79b" name="Squad Size" defaultEntryId="d130-90f6-3eb7-88d4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="d130-90f6-3eb7-88d4" name="Leader and 2 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="18a9-58dc-62ed-a832" name="Leader and 4 Grunts" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -12137,16 +12687,8 @@ damage rolls at one token per attack or boost.</description>
         </link>
       </links>
     </entry>
-    <entry id="dd9fddb3-0a7b-ff57-3d2f-a24be3dac03c" name="Steelhead Riflemen" points="5.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="50">
+    <entry id="dd9fddb3-0a7b-ff57-3d2f-a24be3dac03c" name="Steelhead Riflemen" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="50">
       <entries>
-        <entry id="e4bc5d85-f4f6-6a2d-4d2f-129d7b38a884" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Mercenaries - Forces of Warmachine" page="48">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="3591-083e-bde9-8c0c" name="Swords" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -12188,7 +12730,31 @@ damage rolls at one token per attack or boost.</description>
           <links/>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="561a-960b-0039-b4b5" name="Squad Size" defaultEntryId="88fc-276a-2118-4c86" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="88fc-276a-2118-4c86" name="Leader and 5 Grunts" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="6fd3-fffb-e755-b4c5" name="Leader and 9 Grunts" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers>
         <modifier type="set" field="maxInForce" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions/>
@@ -13910,16 +14476,8 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
         </link>
       </links>
     </entry>
-    <entry id="7123-c368-6601-26a9" name="Winter Guard Infantry" points="4.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="102">
+    <entry id="7123-c368-6601-26a9" name="Winter Guard Infantry" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="102">
       <entries>
-        <entry id="d62b-dbec-2e09-2c43" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="d377-e638-1646-696d" name="Blunderbuss" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -14132,9 +14690,9 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
             </link>
           </links>
         </entry>
-        <entry id="4ad1-e055-cff2-f18b" name="Winter Guard Infrantry Rocketeer" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="104">
+        <entry id="4ad1-e055-cff2-f18b" name="Winter Guard Infrantry Rocketeer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="2" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="104">
           <entries>
-            <entry id="c24a-e689-0652-7bd2" name="1 Rocketeer" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="c24a-e689-0652-7bd2" name="Winter Guard Rocketeer" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -14248,7 +14806,31 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
           </links>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="e062-10f2-4e19-32f9" name="Squad Size" defaultEntryId="b2b0-579a-ed41-0ba4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="b2b0-579a-ed41-0ba4" name="Leader and 5 Grunts" points="4.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="acbf-7309-58be-4738" name="Leader and 9 Grunts" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules/>
       <profiles>
@@ -14432,16 +15014,8 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
         </link>
       </links>
     </entry>
-    <entry id="1d05-31e5-f1f2-c43c" name="Winter Guard Rifle Corps" points="5.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="107">
+    <entry id="1d05-31e5-f1f2-c43c" name="Winter Guard Rifle Corps" points="0.0" categoryId="556e697423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forces of Warmachine: Khador" page="107">
       <entries>
-        <entry id="3e99-2c26-8a14-5f51" name="Leader &amp; 5 Grunts -&gt; Leader &amp; 9 Grunts" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
         <entry id="873d-1669-66b4-9215" name="Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups/>
@@ -14483,7 +15057,31 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
           <links/>
         </entry>
       </entries>
-      <entryGroups/>
+      <entryGroups>
+        <entryGroup id="1fd8-21ef-44ad-a5e0" name="Squad Size" defaultEntryId="44e3-5588-5949-9945" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="44e3-5588-5949-9945" name="Leader and 5 Grunts" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="7203-3e04-6e11-d5fb" name="Leader and 9 Grunts" points="8.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
       <modifiers/>
       <rules>
         <rule id="d8fd-0df9-7cc7-dd96" name="Suppressing Fire (Order)" hidden="false">
@@ -15490,6 +16088,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="5f9a-6067-2f58-e844" name="Deadeye" hidden="false">
+          <description>Target friendly model/unit gains an additional die on each model&apos;s first ranged attack roll this turn.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -15539,6 +16138,11 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="c390-e6ec-438e-b05b" name="Death March" hidden="false">
+          <description>Target friendly unit gains +2 MAT and Vengeance. (During your
+Maintenance Phase, if one or more models in a unit with Vengeance
+were destroyed or removed from play by enemy attacks during your
+opponent’s last turn, each model in the unit can advance 3˝ and make one
+normal melee attack.)</description>
           <modifiers/>
         </rule>
       </rules>
@@ -15813,6 +16417,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="9cd4-2850-9540-333e" name="Energizer" hidden="false">
+          <description>This model spends up to 3 focus points to cast Energizer. Models in its battlegroup that are currently in its control area can immediately advance up to 1˝ for each focus point spent. Energizer can be cast only once per turn.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -15837,6 +16442,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="6d8b-a643-9eb8-eb5b" name="Eruption" hidden="false">
+          <description>Models hit sufer a POW 14 fire damage roll. The AOE is a cloud effect that remains in play for one round. Models entering or ending their activation in the AOE suffer an unboostable POW 14 fire damage roll.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -15936,6 +16542,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="f321-e564-7dcc-8ce8" name="Fire for Effect" hidden="false">
+          <description>Boost the attack and damage rolls of target friendly Faction model&apos;s first ranged attack each activation.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -16169,7 +16776,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
           <characteristics>
             <characteristic characteristicId="434f535423232344415441232323" name="COST" value="3"/>
             <characteristic characteristicId="524e4723232344415441232323" name="RNG" value="SELF"/>
-            <characteristic characteristicId="414f4523232344415441232323" name="AOE" value="CTRØ"/>
+            <characteristic characteristicId="414f4523232344415441232323" name="AOE" value="CTRL"/>
             <characteristic characteristicId="504f5723232344415441232323" name="POW" value="-"/>
             <characteristic characteristicId="555023232344415441232323" name="UP" value="NO"/>
             <characteristic characteristicId="4f464623232344415441232323" name="OFF" value="NO"/>
@@ -16668,6 +17275,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="1ad4-93f4-6736-a6a1" name="Jackhammer" hidden="false">
+          <description>Target model in this model&apos;s battlegroup immediately makes one normal melee. attack.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -16787,9 +17395,9 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="a135-f075-1a00-6311" name="Magic Ability [7]" hidden="false">
-          <description>- Disbinding (* Action) - Enemy upkeep spells on this model and/or its unit immediately expire.
-- Frostbite (* Attack) - Frostbite is a RNG SP 8 magic attack. Models hit suffer a POW 12 cold damage roll.
-- Zephyr (* Action) - Models in this unit that are in formation can immediately advance up to 3&quot;. They cannot be targeted by free strikes during this movement.</description>
+          <description>◦ Disbinding (★ Action) - Enemy upkeep spells on this model and/or its unit immediately expire.
+◦ Frostbite (★ Attack) - Frostbite is a RNG SP 8 magic attack. Models hit suffer a POW 12 cold damage roll.
+◦ Zephyr (★ Action) - Models in this unit that are in formation can immediately advance up to 3&quot;. They cannot be targeted by free strikes during this movement.</description>
           <modifiers/>
         </rule>
         <rule id="1bd0-af9c-afed-4aeb" name="Ranking Officer" hidden="false">
@@ -17481,6 +18089,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="aa8d-f718-36ce-eec5" name="Primed" hidden="false">
+          <description>Target friendly warrior model/unit gains +2 to melee attack and melee damage rolls but suffers -2 ARM. If an affected model is disabled by an enemy attack, center a 3&quot; AOE on it and remove that model from play. Models in the AOE are hit and suffer an unboostable POW 14 blast damage roll.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -17730,6 +18339,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="be4b-500f-92f8-3b37" name="Redline" hidden="false">
+          <description>Target warjack in this model&apos;s battlegroup gains +2 STR and SPD and can run, charge, or make power attack slams or tramples without spending focus. When it ends its activation, it suffers D3 damage points.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -18079,6 +18689,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="7342-5445-cecc-b53d" name="Solid Ground" hidden="false">
+          <description>While in this model&apos;s control area, friendly models cannot be knocked down and do not suffer blast damage.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -18253,6 +18864,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="a862-dedc-8e05-9b27" name="Strength of Granite" hidden="false">
+          <description>Target model in this model&apos;s battlegroup gains +4 STR.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -18427,6 +19039,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <modifiers/>
       <rules>
         <rule id="4e08-89d6-5cc5-55d8" name="Temper Metal" hidden="false">
+          <description>Target friendly warjack gains +2 ARM and is immune to continuous effects.</description>
           <modifiers/>
         </rule>
       </rules>
@@ -18917,7 +19530,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <description>When this model&apos;s melee damage roll fails to exceed the ARM of the living model hit, that model suffers 1 damage point.</description>
       <modifiers/>
     </rule>
-    <rule id="0e05-3016-49df-4a5a" name="Ancillary Attack (* Action)" hidden="false" book="Vengeance" page="86">
+    <rule id="0e05-3016-49df-4a5a" name="Ancillary Attack (★ Action)" hidden="false" book="Vengeance" page="86">
       <description>RNG 5. Target friendly Faction warjack. If the warjack is in range, it immediately makes one normal melee or ranged attack. A warjack can make an Ancillary Attack special action only once per turn.</description>
       <modifiers/>
     </rule>
@@ -18949,11 +19562,11 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <description>When calculating damage from this weapon, halve the base ARM stats of models hit that have medium or larger bases. This weapon gains +2 to damage rolls against models with small bases.</description>
       <modifiers/>
     </rule>
-    <rule id="3f79c3c8-5611-b192-f6be-adae43bab364" name="Armor Piercing (* Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="40">
+    <rule id="3f79c3c8-5611-b192-f6be-adae43bab364" name="Armor Piercing (★ Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="40">
       <description>When calculating damage from this attack, halve the base ARM stats of the models hit that have medium or larger bases. This attack gains +2 to damage rolls against model swith small bases.</description>
       <modifiers/>
     </rule>
-    <rule id="f4d761fa-11cc-0dbb-8814-13fe337094da" name="Artillerist (* Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="128">
+    <rule id="f4d761fa-11cc-0dbb-8814-13fe337094da" name="Artillerist (★ Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="128">
       <description>Choose a friendly Faction model. While in this model&apos;s command range, the chosen model gains +2 to AOE ranged attack rolls. When the chosen model&apos;s AOE ranged attacks deviate, you can reroll the direction and/or distance of the deviation. Each roll can be rerolled only once as a result of Artillerist. Artillerist lasts for one turn.</description>
       <modifiers/>
     </rule>
@@ -18981,7 +19594,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <description>This model gains an additional die on its back strike damage rolls.</description>
       <modifiers/>
     </rule>
-    <rule id="9545312f-dd4b-7a8a-fbba-c7556415ff84" name="Backswing (* Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="49">
+    <rule id="9545312f-dd4b-7a8a-fbba-c7556415ff84" name="Backswing (★ Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="49">
       <description>Make two attack with this weapon.</description>
       <modifiers/>
     </rule>
@@ -19001,7 +19614,7 @@ Incendiary – This attack causes fire damage, and models hit suffer the Fire co
       <description>When making an attack with this weapon, ignore spell effects that add to a model&apos;s ARM or DEF.</description>
       <modifiers/>
     </rule>
-    <rule id="354f488c-bbe0-d555-6e14-d5e14b2240cd" name="Both Barrels (* Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="136">
+    <rule id="354f488c-bbe0-d555-6e14-d5e14b2240cd" name="Both Barrels (★ Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="136">
       <description>This model gains +4 to the damage roll for this attack. This model cannot make additional ranged attacks with this weapon during an activation it makes a Both Barrels attack.</description>
       <modifiers/>
     </rule>
@@ -19090,11 +19703,11 @@ Damaging a colossal
       <description>This model can participate in combined ranged attacks with other models in its unit (p. 62).</description>
       <modifiers/>
     </rule>
-    <rule id="d6d5-1697-fb97-59b2" name="Combo Smite (* Attack)" hidden="false" book="Forces of Warmachine: Khador" page="76">
+    <rule id="d6d5-1697-fb97-59b2" name="Combo Smite (★ Attack)" hidden="false" book="Forces of Warmachine: Khador" page="76">
       <description>Make a melee attack. On a hit, instead of making a normal damage roll the target model is slammed d6&quot; directly away from this model and suffers a damage roll with POW equal to the STR of this model plus twice the POW of this weapon. The POW of collateral damage is equal to this model&apos;s STR.</description>
       <modifiers/>
     </rule>
-    <rule id="bf4e-9c33-3009-f780" name="Combo Strike (* Attack)" hidden="false" book="Forces of Warmachine: Retribution of Scyrah" page="66">
+    <rule id="bf4e-9c33-3009-f780" name="Combo Strike (★ Attack)" hidden="false" book="Forces of Warmachine: Retribution of Scyrah" page="66">
       <description>Make a melee attack. Instead of making a normal damage roll, the POW of the damage roll is equal to this model&apos;s STR plus twice the POW of this weapon.</description>
       <modifiers/>
     </rule>
@@ -19118,7 +19731,7 @@ Damaging a colossal
       <description>When an enemy model advances and ends its movement within 6&quot; of this model and in its LOS, this model can immediately charge it. If it does, it cannot make another counter charge until after your next turn. This model cannot make a counter charge while engaged.</description>
       <modifiers/>
     </rule>
-    <rule id="c535-4a94-39e5-b031" name="Covering Fire (* Action)" hidden="false" book="Forces of Warmachine: Retribution of Scyrah" page="70">
+    <rule id="c535-4a94-39e5-b031" name="Covering Fire (★ Action)" hidden="false" book="Forces of Warmachine: Retribution of Scyrah" page="70">
       <description>Place a 3&quot; AOE anywhere completely within this weapon&apos;s RNG. The canter point of the AOE must be in this model&apos;s LOS, ignoring intervening models. A model entering or ending its activation in the AOE suffers a damage roll with POW equal to the POW of this weapon. The AOE remains in play for one round or until this model is destroyed or removed from play.</description>
       <modifiers/>
     </rule>
@@ -19254,7 +19867,7 @@ Damaging a colossal
       <description>When a warjack or warbeast is hit by this weapon it is knocked down.</description>
       <modifiers/>
     </rule>
-    <rule id="79d00749-2d75-1015-d228-b23ab19ded71" name="Espionage (* Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="66">
+    <rule id="79d00749-2d75-1015-d228-b23ab19ded71" name="Espionage (★ Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="66">
       <description>RNG 5. Target enemy warcaster or warlock. If the enemy warcazster or warlock is in range, firendly models/units in this model&apos;s command range can immediately make a full advance and a normal attack.</description>
       <modifiers/>
     </rule>
@@ -19540,7 +20153,7 @@ Damaging a colossal
       <description>This model will work for Trollbloods.</description>
       <modifiers/>
     </rule>
-    <rule id="07907045-fd54-a779-8c0c-4d8d28bac422" name="Multi-Fire (* Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="86">
+    <rule id="07907045-fd54-a779-8c0c-4d8d28bac422" name="Multi-Fire (★ Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="86">
       <description>Make an attack with this weapon. On a hit, after resolving the attack this model can immediately make one additional attack with this weapon targeting the last  model hit or another model within 2&quot; of the last model hit, ignoring ROF. This model can make up to four attacks during its activation as a result of Multi-Fire.</description>
       <modifiers/>
     </rule>
@@ -19644,7 +20257,7 @@ Damaging a colossal
       <description>This model gains Pathfinder during activations it charges.</description>
       <modifiers/>
     </rule>
-    <rule id="16d1ece1-d456-63ca-5c0c-74ea34967e03" name="Repair[] (* Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="120">
+    <rule id="16d1ece1-d456-63ca-5c0c-74ea34967e03" name="Repair[] (★ Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="120">
       <description>This model can attempt repairs on any damaged friendly Faction warjack. To attempt repairs, this model must be B2B with the damaged warjack and make a skill check. If successful, remove d6 damage points from the warjack&apos;s damage grid.</description>
       <modifiers/>
     </rule>
@@ -19676,7 +20289,7 @@ Damaging a colossal
       <description>This model cannot be targeted by enemy spells.</description>
       <modifiers/>
     </rule>
-    <rule id="3163f8df-14ce-49e2-f47f-55fd58751325" name="Seduction (* Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="70">
+    <rule id="3163f8df-14ce-49e2-f47f-55fd58751325" name="Seduction (★ Action)" hidden="false" book="Mercenaries - Forces of Warmachine" page="70">
       <description>Take control of a living enemy non-warcaster, non-warlock warrior model B2B with this model. You can immediately make a full advance with the enemy model followed by a normal melee attack, then Seduction expires. The nemey model cannot be targeted by free strikes duringt his movement.</description>
       <modifiers/>
     </rule>
@@ -19792,7 +20405,7 @@ Damaging a colossal
       <description>This model is a terrifying entity (p. 84). Enemy models/units in the melee range of this model or with this model in their melee range must pass a command check or flee.</description>
       <modifiers/>
     </rule>
-    <rule id="579ab18e-eb22-6aae-f01d-28868792128f" name="Thresher (* Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="45">
+    <rule id="579ab18e-eb22-6aae-f01d-28868792128f" name="Thresher (★ Attack)" hidden="false" book="Mercenaries - Forces of Warmachine" page="45">
       <description>This model makes one melee attack with this weapon against each model in its LOS and this weapon&apos;s melee range.</description>
       <modifiers/>
     </rule>


### PR DESCRIPTION
Added Black Dragon Officer aand Standard upgrade options to Iron Fang Pikemen

Updated formatting to the following units:
-Assault Kommandos
-Battle Mechaniks
-Greylord Outriders
-Iron Fange Pikemen
-Iron Fang Uhlans
-Kossite Woodsmen
-Man-o-War Bombadiers
-Man-o-War Demo Corp
-Man-o-War Shocktroopers
-Winter Guard Infantry
-Winter Guard Rifle Corp
-Croe's Cutthroats
-Cylena Raefyll & Nyss Hunters
-Greygore Boomhowler & Co.
-Hammerfall High Shield Gun Corp
-Sea Dog Crew
-Steelhead Halberdiers
-Steelhead Heaevy Cavalry
-Steelhead Riflemen
-Press Gangers

Added Kayazy Assassins and unit attachments to the Catalogue

Added Rules to the following shared entries:
-Deadeye
-Deathmarch
-Energizer
-Eruption
-Fire for Effect
-Jackhammer
-Primed
-Redline
-Solid Ground
-Strength of Granite
-Temper Metal
